### PR TITLE
Clarify tutorial text about logging

### DIFF
--- a/templates/module0.html
+++ b/templates/module0.html
@@ -47,7 +47,7 @@
 <ul>
     <li>Un sistema de notificaciones que informa a los usuarios sobre las acciones realizadas, como publicaciones exitosas o errores, mediante mensajes "flash".</li>
     <li>La posibilidad de alternar entre <strong>modo claro y modo oscuro</strong>, lo cual se adapta a sus preferencias de visualización.</li>
-    <li>Un sistema de logs que registra las acciones realizadas por los usuarios (inicio de sesión, acceso a módulos, cambios en usuarios, etc.) para un posible análisis futuro.</li>
+    <li>Se planea implementar un sistema de logs que registre las acciones realizadas por los usuarios (inicio de sesión, acceso a módulos, cambios en usuarios, etc.) para su análisis futuro.</li>
 </ul>
 
 <h3>6. Soporte y Ayuda</h3>


### PR DESCRIPTION
## Summary
- edit module0 tutorial bullet about logging to note that logging is planned instead of already in place

## Testing
- `python3 -m py_compile $(git ls-files '*.py')` *(fails: f-string unmatched '[' in modules/module1.py)*

------
https://chatgpt.com/codex/tasks/task_e_683f431bfe2483299b0c1d59425bb54d